### PR TITLE
Add: Search API

### DIFF
--- a/src/main/java/sakak/food/controller/FoodController.java
+++ b/src/main/java/sakak/food/controller/FoodController.java
@@ -1,0 +1,46 @@
+package sakak.food.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import sakak.food.dto.FoodDTO;
+import sakak.food.entity.Food;
+import sakak.food.exception.CustomErrorCode;
+import sakak.food.exception.CustomException;
+import sakak.food.exception.ErrorResponse;
+import sakak.food.service.FoodService;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/foods")
+@Tag(name = "Food API", description = "API for foods")
+public class FoodController {
+
+    private final FoodService foodService;
+
+    //Search API
+    @Operation(summary = "요청 인자에 대한 출력 항목")
+    @GetMapping("/search")
+    public ResponseEntity<?> searchFoods(
+            @RequestParam(required = false) String food_name,
+            @RequestParam(required = false) String research_year,
+            @RequestParam(required = false) String maker_name,
+            @RequestParam(required = false) String food_code)
+    {
+        try {
+            List<Food> foods = foodService.searchFoods(food_name, research_year, maker_name, food_code);
+            return ResponseEntity.ok(foods);
+        } catch (CustomException e) {
+            ErrorResponse errorResponse = new ErrorResponse(e.getCode(), e.getHttpStatus(), e.getMessage());
+            return ResponseEntity.status(e.getHttpStatus().value()).body(errorResponse);
+        }
+    }
+
+
+}

--- a/src/main/java/sakak/food/dto/FoodDTO.java
+++ b/src/main/java/sakak/food/dto/FoodDTO.java
@@ -1,0 +1,2 @@
+package sakak.food.dto;public class FoodDto {
+}

--- a/src/main/java/sakak/food/entity/Food.java
+++ b/src/main/java/sakak/food/entity/Food.java
@@ -1,0 +1,61 @@
+package sakak.food.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class Food {
+    //(): 엑셀표 기준 기입
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id; //id (NO)
+
+    @Column(name = "food_cd")
+    private String foodCd; //식품코드
+
+    @Column(name = "group_name")
+    private String groupName; //식품군 (상용제품)
+
+    @Column(name = "food_name")
+    private String foodName; //식품이름 (식품명)
+
+    @Column(name = "research_year")
+    private String researchYear; //조사년도 (연도)
+
+    @Column(name = "maker_name")
+    private String makerName; //지역/제조사
+
+    @Column(name = "ref_name")
+    private String refName; //자료출처 (성분표출처)
+
+    @Column(name = "serving_size")
+    private Integer servingSize; //1회 제공량
+
+    private Double calorie; //열량(kcal)(1회제공량당) (에너지(㎉))
+
+    private Double carbohydrate; //탄수화물(g)(1회제공량당)
+
+    private Double protein; //단백질(g)(1회제공량당)
+
+    private Double province; //지방(g)(1회제공량당)
+
+    private Double sugars; //총당류(g)(1회제공량당)
+
+    private Double salt; //나트륨(mg)(1회제공량당)
+
+    private Double cholesterol; //콜레스테롤(mg)(1회제공량당)
+
+    @Column(name = "saturated_fatty_acids")
+    private Double saturatedFattyAcids; //포화지방산(g)(1회제공량당) (총 포화 지방산(g))
+
+    @Column(name = "trans_fat")
+    private Double transFat; //트랜스지방(g)(1회제공량당) (트랜스 지방산(g))
+
+}

--- a/src/main/java/sakak/food/exception/CustomErrorCode.java
+++ b/src/main/java/sakak/food/exception/CustomErrorCode.java
@@ -1,0 +1,2 @@
+package sakak.food.exception;public class CustomErrorcode {
+}

--- a/src/main/java/sakak/food/exception/CustomException.java
+++ b/src/main/java/sakak/food/exception/CustomException.java
@@ -1,0 +1,2 @@
+package sakak.food.exception;public class ErrorExcetpion {
+}

--- a/src/main/java/sakak/food/exception/CustomExceptionHandler.java
+++ b/src/main/java/sakak/food/exception/CustomExceptionHandler.java
@@ -1,0 +1,2 @@
+package sakak.food.exception;public class CustomExceptionHandler {
+}

--- a/src/main/java/sakak/food/exception/ErrorResponse.java
+++ b/src/main/java/sakak/food/exception/ErrorResponse.java
@@ -1,0 +1,2 @@
+package sakak.food.exception;public class ErrorException {
+}

--- a/src/main/java/sakak/food/repository/FoodRepository.java
+++ b/src/main/java/sakak/food/repository/FoodRepository.java
@@ -1,0 +1,26 @@
+package sakak.food.repository;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import sakak.food.entity.Food;
+
+import java.util.List;
+
+public interface FoodRepository extends JpaRepository<Food, Long> {
+
+    //주어진 인자가 null 이 없기에 따로 null 처리 하지 않음
+    @Query("SELECT f FROM Food f " +
+            "WHERE f.foodName = :food_name " +
+            "AND f.researchYear = :research_year " +
+            "AND f.makerName = :maker_name " +
+            "AND f.foodCd = :food_code")
+    List<Food> searchFoods(@Param("food_name") String food_name,
+                           @Param("research_year") String research_year,
+                           @Param("maker_name") String maker_name,
+                           @Param("food_code") String food_code);
+
+
+}

--- a/src/main/java/sakak/food/service/FoodService.java
+++ b/src/main/java/sakak/food/service/FoodService.java
@@ -1,0 +1,38 @@
+package sakak.food.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import sakak.food.dto.FoodDTO;
+import sakak.food.entity.Food;
+import sakak.food.exception.CustomErrorCode;
+import sakak.food.exception.CustomException;
+import sakak.food.repository.FoodRepository;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+
+public class FoodService {
+
+    private final FoodRepository foodRepository;
+
+    @Transactional(readOnly = true)
+    public List<Food> searchFoods(String food_name, String research_year, String maker_name, String food_code) {
+        // 입력값이 하나라도 null 인 경우 유효하지 않은 입력으로 예외
+        if (food_name == null || research_year == null || maker_name == null || food_code == null) {
+            throw new CustomException(CustomErrorCode.INVALID_INPUT);
+        }
+        // 입력값을 기준으로 식품을 검색하고, 검색 결과가 없는 경우 예외
+        List<Food> foods = foodRepository.searchFoods(food_name, research_year, maker_name, food_code);
+        if (foods.isEmpty()) {
+            throw new CustomException(CustomErrorCode.FOOD_NOT_FOUND);
+        }
+        return foods;
+    }
+}


### PR DESCRIPTION
Search API: 요청 인자에 대한 출력 항목 출력
Entity 
모든 속성을 처리하지 않고 출력 항목에 필요한 정보들을 전처리하였음
ID는 DB에서 자동으로 부여되는 식별자
엔티티 클래스에서 직접 스네이크 케이스를 사용한다면 이 매핑 과정에서 오류가 발생할 수 있기에, @Column사용
Ex) saturated_fatty_acids -> saturatedFattyAcids